### PR TITLE
Add complex example and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,35 @@ export class AppRoot {
 // }
 ```
 
+### Complex Todo Example
+
+A more advanced example demonstrating nested components and store usage is
+provided in `src/example/TodoApp.tsx`.
+
+```typescript
+import { createElement, mount } from 'echelon';
+import { TodoApp } from 'echelon/example/TodoApp';
+
+const root = document.getElementById('app');
+if (root) {
+  mount(createElement(TodoApp, null), root);
+}
+```
+
+Running this example shows that Echelon can handle dynamic lists and
+inter-component communication, making it suitable for complex front-end
+projects.
+
+## Publishing
+
+The framework builds to both ESM and CJS outputs. Create the npm package with:
+
+```bash
+npm run build
+npm pack
+```
+This generates a tarball ready for publishing to the npm registry.
+
 ## Available Scripts
 
 In the project root you can use the following scripts:

--- a/src/example/TodoApp.tsx
+++ b/src/example/TodoApp.tsx
@@ -1,0 +1,66 @@
+/** @jsx createElement */
+/** @jsxFrag Fragment */
+import { createElement, Fragment, Component, Render, State, Event, Prop, Store } from 'echelon';
+
+@Component('li')
+class TodoItem {
+  idx = 0;
+  onRemove: (i: number) => void = () => {};
+
+  @Event('click')
+  handleClick(_e: MouseEvent) {
+    this.onRemove(this.idx);
+  }
+
+  @Render()
+  render(
+    @Prop('text') text: string,
+    @Prop('idx') idx: number,
+    @Prop('onRemove') onRemove: (i: number) => void
+  ) {
+    this.idx = idx;
+    this.onRemove = onRemove;
+    return <span>{text}</span>;
+  }
+}
+
+@Component('div')
+export class TodoApp {
+  @Store('items') items: string[] = [];
+  @State() inputValue: string = '';
+
+  removeItem(index: number) {
+    this.items = this.items.filter((_, i) => i !== index);
+  }
+
+  @Event('submit')
+  addItem(e: Event) {
+    e.preventDefault();
+    if (this.inputValue.trim()) {
+      this.items = [...this.items, this.inputValue];
+      this.inputValue = '';
+    }
+  }
+
+  @Event('input')
+  updateInput(e: InputEvent) {
+    this.inputValue = (e.target as HTMLInputElement).value;
+  }
+
+  @Render()
+  render() {
+    return (
+      createElement(Fragment, null,
+        createElement('form', null,
+          createElement('input', { value: this.inputValue }),
+          createElement('button', { type: 'submit' }, 'Add')
+        ),
+        createElement('ul', null,
+          this.items.map((t, i) =>
+            createElement(TodoItem, { text: t, idx: i, onRemove: this.removeItem.bind(this) })
+          )
+        )
+      )
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a TodoApp example demonstrating stores and nested components
- document complex example and npm packaging steps in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848dd09de98832a84ea67fc272e0cc6