### PR TITLE
Add simple router with decorators

### DIFF
--- a/src/core/decorators.ts
+++ b/src/core/decorators.ts
@@ -20,6 +20,8 @@ function getOrCreateComponentMeta(targetOrConstructor: any): ComponentMeta {
       propMappings: new Map(),
       stateFields: new Set(),
       storeFields: new Map(),
+      routeParamFields: new Map(),
+      queryParamFields: new Map(),
       // tagName, renderMethodName 등은 데코레이터에서 직접 설정
     };
     Reflect.defineMetadata(COMPONENT_META_KEY, newMeta, constructor);
@@ -36,6 +38,8 @@ function getOrCreateComponentMeta(targetOrConstructor: any): ComponentMeta {
   if (!meta.propMappings) meta.propMappings = new Map();
   if (!meta.stateFields) meta.stateFields = new Set();
   if (!meta.storeFields) meta.storeFields = new Map();
+  if (!meta.routeParamFields) meta.routeParamFields = new Map();
+  if (!meta.queryParamFields) meta.queryParamFields = new Map();
 
   return meta;
 }
@@ -203,3 +207,21 @@ export function Children() {
     meta.childrenParamIndex = parameterIndex;
   };
 }
+export function Param(name: string) {
+  return function (target: any, classFieldName: string | symbol) {
+    const meta = getOrCreateComponentMeta(target);
+    if (!meta.routeParamFields) meta.routeParamFields = new Map();
+    meta.routeParamFields.set(classFieldName, name);
+    meta.stateFields.add(classFieldName);
+  };
+}
+
+export function Query(name: string) {
+  return function (target: any, classFieldName: string | symbol) {
+    const meta = getOrCreateComponentMeta(target);
+    if (!meta.queryParamFields) meta.queryParamFields = new Map();
+    meta.queryParamFields.set(classFieldName, name);
+    meta.stateFields.add(classFieldName);
+  };
+}
+

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -214,6 +214,23 @@ function createComponentInstance(
 
   const componentObject = new ComponentClass(); // 생성자 인자는 props에서 받거나 다른 방식으로 처리 가능
 
+  if (meta.routeParamFields && propsFromJsx.__routeParams) {
+    meta.routeParamFields.forEach((paramName, field) => {
+      if (paramName in propsFromJsx.__routeParams) {
+        (componentObject as any)[field] = propsFromJsx.__routeParams[paramName];
+      }
+    });
+  }
+  if (meta.queryParamFields && propsFromJsx.__queryParams) {
+    meta.queryParamFields.forEach((queryName, field) => {
+      if (queryName in propsFromJsx.__queryParams) {
+        (componentObject as any)[field] = propsFromJsx.__queryParams[queryName];
+      }
+    });
+  }
+  delete (propsFromJsx as any).__routeParams;
+  delete (propsFromJsx as any).__queryParams;
+
   let hostDomElement: HTMLElement | DocumentFragment;
   if (meta.tagName) {
     hostDomElement = document.createElement(meta.tagName);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -28,6 +28,8 @@ export interface ComponentMeta {
   stateFields: Set<string | symbol>;
   storeFields?: Map<string | symbol, string>;
   watchHandlers?: Map<string | symbol, Array<string | symbol>>;
+  routeParamFields?: Map<string | symbol, string>;
+  queryParamFields?: Map<string | symbol, string>;
 }
 
 export interface EchelonInternalComponentInstance {

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,15 @@ export { mount } from './core/renderer';
 export type { EchelonElement } from './core/jsx';
 export type { EchelonInternalComponentInstance, ComponentMeta, INTERNAL_INSTANCE_KEY } from './core/types';
 
+export {
+  Router,
+  RouterOutlet,
+  Link,
+  navigate,
+  Param,
+  Query,
+} from './router';
+
 // Babel JSX pragma가 createElement, Fragment를 찾을 수 있도록 전역 설정 (선택적, 권장되지 않음)
 // if (typeof window !== 'undefined') {
 //   if (!(window as any).createElement) (window as any).createElement = createElement;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,0 +1,3 @@
+export { Router, RouterOutlet, Link, navigate } from './router';
+export type { RouteRecord, RouteMatch } from './types';
+export { Param, Query } from '../core/decorators';

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -1,0 +1,95 @@
+import { createElement, Fragment } from 'echelon/core/jsx';
+import { Component, Render, Mounted, Destroyed, Event, Property, Children } from 'echelon/core/decorators';
+import { setStoreValue, getStoreValue, subscribeStore } from 'echelon/core/store';
+import type { RouteRecord } from './types';
+import { resolveRoute } from './utils';
+
+const ROUTER_STORE_ID = '__echelon_router__';
+
+export function navigate(path: string): void {
+  history.pushState(null, '', path);
+  const info = getStoreValue(ROUTER_STORE_ID);
+  setStoreValue(ROUTER_STORE_ID, { path, routes: info?.routes || [] });
+}
+
+@Component('a')
+export class Link {
+  @Property('href') to: string = '';
+
+  @Event('click')
+  handleClick(e: MouseEvent) {
+    e.preventDefault();
+    navigate(this.to);
+  }
+
+  @Render()
+  render(@Children() children: any) {
+    return createElement(Fragment, null, ...(Array.isArray(children) ? children : [children]));
+  }
+}
+
+@Component()
+export class Router {
+  routes: RouteRecord[] = [];
+
+  @Mounted()
+  init() {
+    window.addEventListener('popstate', this.updatePath);
+    this.updatePath();
+  }
+
+  @Destroyed()
+  cleanup() {
+    window.removeEventListener('popstate', this.updatePath);
+  }
+
+  updatePath = () => {
+    setStoreValue(ROUTER_STORE_ID, { path: location.pathname + location.search, routes: this.routes });
+  };
+
+  @Render()
+  render(@Children() children: any) {
+    return createElement(Fragment, null, ...(Array.isArray(children) ? children : [children]));
+  }
+}
+
+@Component()
+export class RouterOutlet {
+  private unsubscribe?: () => void;
+  private currentElement: any = null;
+
+  private compute() {
+    const info = getStoreValue(ROUTER_STORE_ID) as { path: string; routes: RouteRecord[] } | undefined;
+    if (!info) {
+      this.currentElement = null;
+      return;
+    }
+    const match = resolveRoute(info.path, info.routes);
+    if (match) {
+      this.currentElement = createElement(match.component, {
+        __routeParams: match.params,
+        __queryParams: match.query,
+      });
+    } else {
+      this.currentElement = null;
+    }
+  }
+
+  @Mounted()
+  mounted() {
+    this.compute();
+    this.unsubscribe = subscribeStore(ROUTER_STORE_ID, () => {
+      this.compute();
+    });
+  }
+
+  @Destroyed()
+  destroyed() {
+    this.unsubscribe?.();
+  }
+
+  @Render()
+  render() {
+    return this.currentElement;
+  }
+}

--- a/src/router/types.ts
+++ b/src/router/types.ts
@@ -1,0 +1,12 @@
+export interface RouteRecord {
+  path: string;
+  component: new (...args: any[]) => any;
+  guard?: () => boolean;
+  _compiled?: { regex: RegExp; keys: string[] };
+}
+
+export interface RouteMatch {
+  component: new (...args: any[]) => any;
+  params: Record<string, string>;
+  query: Record<string, string>;
+}

--- a/src/router/utils.ts
+++ b/src/router/utils.ts
@@ -1,0 +1,42 @@
+import type { RouteRecord, RouteMatch } from './types';
+
+function compilePath(path: string): { regex: RegExp; keys: string[] } {
+  const keys: string[] = [];
+  const regexString = path
+    .replace(/\//g, '\\/')
+    .replace(/:([^/]+)/g, (_, key) => {
+      keys.push(key);
+      return '([^/]+)';
+    });
+  const regex = new RegExp(`^${regexString}$`);
+  return { regex, keys };
+}
+
+function parseQuery(search: string): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (!search) return params;
+  const usp = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  usp.forEach((v, k) => {
+    params[k] = v;
+  });
+  return params;
+}
+
+export function resolveRoute(path: string, routes: RouteRecord[]): RouteMatch | null {
+  const [pathname, search = ''] = path.split('?');
+  for (const r of routes) {
+    if (!r._compiled) r._compiled = compilePath(r.path);
+    const match = r._compiled.regex.exec(pathname);
+    if (match) {
+      if (r.guard && !r.guard()) continue;
+      const params: Record<string, string> = {};
+      r._compiled.keys.forEach((k, i) => (params[k] = match[i + 1]));
+      return {
+        component: r.component,
+        params,
+        query: parseQuery(search),
+      };
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- extend component metadata to track route and query bindings
- implement `Param` and `Query` decorators
- create router utilities and components (`Router`, `RouterOutlet`, `Link`)
- expose router APIs in the main entry
- inject route parameters during component instantiation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848f1a89a50832a949dd59d09c4762e