### PR TITLE
Add documentation pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Echelon Framework
 
-## Overview
-
-Echelon is a new framework supporting decorator driven reactivity and JSX/TSX syntax. Its component based architecture is designed for building web applications efficiently.
+Echelon is a decorator-driven framework with full JSX/TSX support. It lets you build modular components in TypeScript with minimal boilerplate.
 
 ## Key Features
 
@@ -13,139 +11,31 @@ Echelon is a new framework supporting decorator driven reactivity and JSX/TSX sy
 * **Event handling**: Handle DOM events easily via the `@Event` decorator.
 * **Lifecycle management**: Define lifecycle hooks like `@Mounted` for components.
 
-## Installation
+## Quick Start
 
 ```bash
-npm install
-# or
-yarn install
+npm install echelon
 ```
-
-## Usage
-
-### Basic Component Example
-
-Below is a simple counter component built with Echelon.
 
 ```typescript jsx
-// src/example/MyComponent.tsx
-/** @jsx createElement */
-/** @jsxFrag Fragment */
-import { createElement, Fragment, Component, Render, State, Event, Prop, Children, Mounted } from 'echelon';
+import { createElement, Component, Render, State, mount } from 'echelon';
 
-@Component('div') // This component renders as a <div> tag.
-class MyClicker {
-  @State() count: number = 0;
-
-  @Event('click')
-  handleClick(event: MouseEvent) {
-    console.log('Clicked at:', event.clientX, event.clientY);
-    this.count++;
-  }
-
-  @Render()
-  render(@Prop('initialMessage') message: string, @Children() children: Node[]) {
-    return (
-      <>
-        <h1>{message}</h1>
-        <p>Current count: {this.count}</p>
-        {children}
-      </>
-    );
-  }
-}
-
-@Component() // Without a tag name a DocumentFragment is used as the host element.
-export class AppRoot {
-  @State() messageForChild: string = "Hello Echelon!";
-
-  @Mounted()
-  onAppMounted() {
-    console.log("AppRoot component has been mounted!");
-    setTimeout(() => {
-      this.messageForChild = "Message updated after 2 seconds!";
-    }, 2000);
-  }
-
+@Component('button')
+class Counter {
+  @State() count = 0;
   @Render()
   render() {
-    return (
-      <MyClicker initialMessage={this.messageForChild}>
-        <button>Click Me!</button>
-        <p>This is a child passed to MyClicker.</p>
-      </MyClicker>
-    );
+    return <span>{this.count}</span>;
   }
 }
-
-// Application mount example (e.g. src/index.ts or main.ts)
-// import { mount } from 'echelon';
-// import { AppRoot } from './example/MyComponent';
-//
-// const appRootElement = document.getElementById('app');
-// if (appRootElement) {
-//   mount(<AppRoot />, appRootElement);
-// }
-```
-
-### Style Decorators
-
-You can bind class fields to DOM styles using `@Style` and `@StyleLayout`.
-
-```typescript jsx
-@Component('div')
-class StyledBox {
-  @Style() backgroundColor = 'blue'; // becomes background-color
-  @StyleLayout() style = { color: 'white', transition: 'all 0.2s ease' };
-
-  @Render()
-  render() {
-    return <span>Styled content</span>;
-  }
-}
-```
-
-### Complex Todo Example
-
-A more advanced example demonstrating nested components and store usage is
-provided in `src/example/TodoApp.tsx`.
-
-```typescript
-import { createElement, mount } from 'echelon';
-import { TodoApp } from 'echelon/example/TodoApp';
 
 const root = document.getElementById('app');
 if (root) {
-  mount(createElement(TodoApp, null), root);
+  mount(<Counter />, root);
 }
 ```
 
-Running this example shows that Echelon can handle dynamic lists and
-inter-component communication, making it suitable for complex front-end
-projects.
-
-## Publishing
-
-The framework builds to both ESM and CJS outputs. Create the npm package with:
-
-```bash
-npm run build
-npm pack
-```
-This generates a tarball ready for publishing to the npm registry.
-
-## Available Scripts
-
-In the project root you can use the following scripts:
-
-* `npm run dev`: Run the application in development mode with automatic rebuilds on file changes.
-* `npm run build`: Build the application for production. Output is placed in the `dist` directory.
-* `npm run clean`: Remove the `dist` directory.
-* `npm run lint`: Check code style with ESLint.
-* `npm run format`: Automatically format code using Prettier.
-* `npm test`: Run unit tests using Jest.
-* `npm run test:watch`: Run Jest in watch mode to re-run tests on changes.
-* `npm run test:cov`: Generate a test coverage report using Jest.
+For full installation instructions and a detailed tutorial, see the [documentation](docs/README.md).
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Echelon Documentation
+
+This directory contains guides for using the framework.
+
+- [Installation](installation.md)
+- [Tutorial](tutorial.md)
+

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,31 @@
+# Installation
+
+```bash
+npm install
+# or
+yarn install
+```
+
+## Publishing
+
+The framework builds to both ESM and CJS outputs. Create the npm package with:
+
+```bash
+npm run build
+npm pack
+```
+
+This generates a tarball ready for publishing to the npm registry.
+
+## Available Scripts
+
+In the project root you can use the following scripts:
+
+* `npm run dev`: Run the application in development mode with automatic rebuilds on file changes.
+* `npm run build`: Build the application for production. Output is placed in the `dist` directory.
+* `npm run clean`: Remove the `dist` directory.
+* `npm run lint`: Check code style with ESLint.
+* `npm run format`: Automatically format code using Prettier.
+* `npm test`: Run unit tests using Jest.
+* `npm run test:watch`: Run Jest in watch mode to re-run tests on changes.
+* `npm run test:cov`: Generate a test coverage report using Jest.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,0 +1,99 @@
+# Tutorial
+
+## Basic Component Example
+
+Below is a simple counter component built with Echelon.
+
+```typescript jsx
+// src/example/MyComponent.tsx
+/** @jsx createElement */
+/** @jsxFrag Fragment */
+import { createElement, Fragment, Component, Render, State, Event, Prop, Children, Mounted } from 'echelon';
+
+@Component('div') // This component renders as a <div> tag.
+class MyClicker {
+  @State() count: number = 0;
+
+  @Event('click')
+  handleClick(event: MouseEvent) {
+    console.log('Clicked at:', event.clientX, event.clientY);
+    this.count++;
+  }
+
+  @Render()
+  render(@Prop('initialMessage') message: string, @Children() children: Node[]) {
+    return (
+      <>
+        <h1>{message}</h1>
+        <p>Current count: {this.count}</p>
+        {children}
+      </>
+    );
+  }
+}
+
+@Component() // Without a tag name a DocumentFragment is used as the host element.
+export class AppRoot {
+  @State() messageForChild: string = "Hello Echelon!";
+
+  @Mounted()
+  onAppMounted() {
+    console.log("AppRoot component has been mounted!");
+    setTimeout(() => {
+      this.messageForChild = "Message updated after 2 seconds!";
+    }, 2000);
+  }
+
+  @Render()
+  render() {
+    return (
+      <MyClicker initialMessage={this.messageForChild}>
+        <button>Click Me!</button>
+        <p>This is a child passed to MyClicker.</p>
+      </MyClicker>
+    );
+  }
+}
+
+// Application mount example (e.g. src/index.ts or main.ts)
+// import { mount } from 'echelon';
+// import { AppRoot } from './example/MyComponent';
+//
+// const appRootElement = document.getElementById('app');
+// if (appRootElement) {
+//   mount(<AppRoot />, appRootElement);
+// }
+```
+
+## Style Decorators
+
+You can bind class fields to DOM styles using `@Style` and `@StyleLayout`.
+
+```typescript jsx
+@Component('div')
+class StyledBox {
+  @Style() backgroundColor = 'blue'; // becomes background-color
+  @StyleLayout() style = { color: 'white', transition: 'all 0.2s ease' };
+
+  @Render()
+  render() {
+    return <span>Styled content</span>;
+  }
+}
+```
+
+## Complex Todo Example
+
+A more advanced example demonstrating nested components and store usage is provided in `src/example/TodoApp.tsx`.
+
+```typescript
+import { createElement, mount } from 'echelon';
+import { TodoApp } from 'echelon/example/TodoApp';
+
+const root = document.getElementById('app');
+if (root) {
+  mount(createElement(TodoApp, null), root);
+}
+```
+
+Running this example shows that Echelon can handle dynamic lists and inter-component communication, making it suitable for complex front-end projects.


### PR DESCRIPTION
## Summary
- simplify README with quick showcase
- create docs directory with installation and tutorial guides

## Testing
- `npm run lint` *(fails: ESLint tsconfig issue)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848f814bc10832a9ea67742d11be2f7